### PR TITLE
feat(ui): add tooltips to navigation and settings controls

### DIFF
--- a/components/app/AppSidebar.vue
+++ b/components/app/AppSidebar.vue
@@ -1,8 +1,30 @@
 <script setup lang="ts">
 import { useSettingsStore } from '~/stores/settings';
+import type { VNode } from 'vue';
+
 const settingsStore = useSettingsStore();
 const isSmallViewport = useMediaQuery('(min-width: 768px)');
 const { fadeTransition, radiusClasses } = useUIUtils();
+
+defineSlots<{
+	default?: () => VNode | VNode[];
+	footer?: () => VNode | VNode[];
+}>();
+
+// Tooltip configuration
+const tooltipContent = {
+	side: 'right',
+	align: 'center',
+	sideOffset: 8,
+	alignOffset: 0,
+} as const;
+
+// Custom UI configuration for larger tooltips
+const tooltipUI = {
+	content:
+		'flex items-center gap-1 bg-[var(--ui-bg)] text-[var(--ui-text-highlighted)] shadow-sm rounded-[var(--ui-radius)] ring ring-[var(--ui-border)] h-8 px-3 py-1 text-sm select-none data-[state=delayed-open]:animate-[scale-in_100ms_ease-out] data-[state=closed]:animate-[scale-out_100ms_ease-in]',
+	text: 'truncate font-medium',
+} as const;
 </script>
 
 <template>
@@ -12,21 +34,70 @@ const { fadeTransition, radiusClasses } = useUIUtils();
 			'transition-[width] duration-300 drop-shadow-sm',
 			settingsStore.sidebarOpen ? 'w-56' : 'w-14',
 		]">
-		<UButton
-			:class="['h-10 flex w-full justify-center', radiusClasses]"
-			@click="settingsStore.toggleSidebar">
-			<UIcon
-				name="i-heroicons-bars-3"
-				class="fixed left-4 w-6 h-6" />
-			<Transition v-bind="fadeTransition">
-				<span v-if="settingsStore.sidebarOpen">Sidebar</span>
-			</Transition>
-		</UButton>
+		<UTooltip
+			:text="settingsStore.sidebarOpen ? '' : 'Toggle Sidebar'"
+			:content="tooltipContent"
+			:ui="tooltipUI">
+			<UButton
+				:class="['h-10 flex w-full justify-center', radiusClasses]"
+				@click="settingsStore.toggleSidebar">
+				<UIcon
+					name="i-heroicons-bars-3"
+					class="fixed left-4 w-6 h-6" />
+				<Transition v-bind="fadeTransition">
+					<span v-if="settingsStore.sidebarOpen">Sidebar</span>
+				</Transition>
+			</UButton>
+		</UTooltip>
 		<div class="flex-1 flex flex-col gap-1 py-1 border-y border-[var(--ui-border-accented)]">
-			<slot />
+			<slot
+				v-if="settingsStore.sidebarOpen"
+				name="default" />
+			<template v-else>
+				<UTooltip
+					text="Chat"
+					:content="tooltipContent"
+					:ui="tooltipUI">
+					<UButton
+						:to="'/'"
+						:class="['h-10 flex w-full justify-center', radiusClasses]">
+						<UIcon
+							name="i-heroicons-chat-bubble-left-right"
+							class="fixed left-4 w-6 h-6" />
+					</UButton>
+				</UTooltip>
+				<UTooltip
+					text="Models"
+					:content="tooltipContent"
+					:ui="tooltipUI">
+					<UButton
+						:to="'/models'"
+						:class="['h-10 flex w-full justify-center', radiusClasses]">
+						<UIcon
+							name="i-heroicons-circle-stack"
+							class="fixed left-4 w-6 h-6" />
+					</UButton>
+				</UTooltip>
+			</template>
 		</div>
 		<div>
-			<slot name="footer" />
+			<slot
+				v-if="settingsStore.sidebarOpen"
+				name="footer" />
+			<template v-else>
+				<UTooltip
+					text="Settings"
+					:content="tooltipContent"
+					:ui="tooltipUI">
+					<UButton
+						:to="'/settings'"
+						:class="['h-10 flex w-full justify-center', radiusClasses]">
+						<UIcon
+							name="i-heroicons-cog-6-tooth"
+							class="fixed left-4 w-6 h-6" />
+					</UButton>
+				</UTooltip>
+			</template>
 		</div>
 	</div>
 	<!-- OVERLAY -->

--- a/components/settings/appearance/BorderSelector.vue
+++ b/components/settings/appearance/BorderSelector.vue
@@ -1,6 +1,19 @@
 <script setup lang="ts">
 const settingsStore = useSettingsStore();
 const { radiusClasses } = useUIUtils();
+
+// Tooltip configuration
+const tooltipContent = {
+	side: 'bottom',
+	align: 'center',
+	sideOffset: 4,
+} as const;
+
+const tooltipUI = {
+	content:
+		'flex items-center gap-1 bg-[var(--ui-bg)] text-[var(--ui-text-highlighted)] shadow-sm rounded-[var(--ui-radius)] ring ring-[var(--ui-border)] h-7 px-2 py-1 text-xs select-none',
+	text: 'truncate font-medium',
+} as const;
 </script>
 
 <template>
@@ -30,20 +43,25 @@ const { radiusClasses } = useUIUtils();
 			orientation="horizontal"
 			@update:model-value="(value: string) => settingsStore.setRadius(value as 'none' | 'xs' | 'sm' | 'md' | 'lg')">
 			<template #label="{ item, modelValue }">
-				<div
-					class="w-6 h-6 bg-[var(--ui-primary)] transition-all duration-200 ring-2 ring-offset-2 dark:ring-offset-gray-900 hover:scale-110"
-					:class="[
-						modelValue === item.value ? 'ring-gray-400 dark:ring-gray-500' : 'ring-transparent',
-						item.value === 'none'
-							? 'rounded-none'
-							: item.value === 'xs'
-								? 'rounded'
-								: item.value === 'sm'
-									? 'rounded-md'
-									: item.value === 'md'
-										? 'rounded-lg'
-										: 'rounded-xl',
-					]" />
+				<UTooltip
+					:text="`${item.label}rem`"
+					:content="tooltipContent"
+					:ui="tooltipUI">
+					<div
+						class="w-6 h-6 bg-[var(--ui-primary)] transition-all duration-200 ring-2 ring-offset-2 dark:ring-offset-gray-900 hover:scale-110"
+						:class="[
+							modelValue === item.value ? 'ring-gray-400 dark:ring-gray-500' : 'ring-transparent',
+							item.value === 'none'
+								? 'rounded-none'
+								: item.value === 'xs'
+									? 'rounded'
+									: item.value === 'sm'
+										? 'rounded-md'
+										: item.value === 'md'
+											? 'rounded-lg'
+											: 'rounded-xl',
+						]" />
+				</UTooltip>
 			</template>
 		</URadioGroup>
 	</div>

--- a/components/settings/appearance/NeutralSelector.vue
+++ b/components/settings/appearance/NeutralSelector.vue
@@ -1,6 +1,19 @@
 <script setup lang="ts">
 const settingsStore = useSettingsStore();
 const { radiusClasses } = useUIUtils();
+
+// Tooltip configuration
+const tooltipContent = {
+	side: 'bottom',
+	align: 'center',
+	sideOffset: 4,
+} as const;
+
+const tooltipUI = {
+	content:
+		'flex items-center gap-1 bg-[var(--ui-bg)] text-[var(--ui-text-highlighted)] shadow-sm rounded-[var(--ui-radius)] ring ring-[var(--ui-border)] h-7 px-2 py-1 text-xs select-none capitalize',
+	text: 'truncate font-medium',
+} as const;
 </script>
 
 <template>
@@ -32,9 +45,17 @@ const { radiusClasses } = useUIUtils();
 				(value: string) => settingsStore.setNeutral(value as 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone')
 			">
 			<template #label="{ item, modelValue }">
-				<div
-					class="w-6 h-6 rounded-full transition-all duration-200 ring-2 ring-offset-2 dark:ring-offset-gray-900 hover:scale-110"
-					:class="[item.class, modelValue === item.value ? 'ring-gray-400 dark:ring-gray-500' : 'ring-transparent']" />
+				<UTooltip
+					:text="item.value"
+					:content="tooltipContent"
+					:ui="tooltipUI">
+					<div
+						class="w-6 h-6 rounded-full transition-all duration-200 ring-2 ring-offset-2 dark:ring-offset-gray-900 hover:scale-110"
+						:class="[
+							item.class,
+							modelValue === item.value ? 'ring-gray-400 dark:ring-gray-500' : 'ring-transparent',
+						]" />
+				</UTooltip>
 			</template>
 		</URadioGroup>
 	</div>

--- a/components/settings/appearance/ThemeSelector.vue
+++ b/components/settings/appearance/ThemeSelector.vue
@@ -1,6 +1,19 @@
 <script setup lang="ts">
 const settingsStore = useSettingsStore();
 const { radiusClasses } = useUIUtils();
+
+// Tooltip configuration
+const tooltipContent = {
+	side: 'bottom',
+	align: 'center',
+	sideOffset: 4,
+} as const;
+
+const tooltipUI = {
+	content:
+		'flex items-center gap-1 bg-[var(--ui-bg)] text-[var(--ui-text-highlighted)] shadow-sm rounded-[var(--ui-radius)] ring ring-[var(--ui-border)] h-7 px-2 py-1 text-xs select-none capitalize',
+	text: 'truncate font-medium',
+} as const;
 </script>
 
 <template>
@@ -35,9 +48,17 @@ const { radiusClasses } = useUIUtils();
 					settingsStore.setTheme(value as 'blue' | 'green' | 'red' | 'yellow' | 'purple' | 'pink' | 'indigo')
 			">
 			<template #label="{ item, modelValue }">
-				<div
-					class="w-6 h-6 rounded-full transition-all duration-200 ring-2 ring-offset-2 dark:ring-offset-gray-900 hover:scale-110"
-					:class="[item.class, modelValue === item.value ? 'ring-gray-400 dark:ring-gray-500' : 'ring-transparent']" />
+				<UTooltip
+					:text="item.value"
+					:content="tooltipContent"
+					:ui="tooltipUI">
+					<div
+						class="w-6 h-6 rounded-full transition-all duration-200 ring-2 ring-offset-2 dark:ring-offset-gray-900 hover:scale-110"
+						:class="[
+							item.class,
+							modelValue === item.value ? 'ring-gray-400 dark:ring-gray-500' : 'ring-transparent',
+						]" />
+				</UTooltip>
 			</template>
 		</URadioGroup>
 	</div>


### PR DESCRIPTION
- Add tooltips to sidebar navigation buttons showing when collapsed
- Add tooltips to theme color selector showing color names
- Add tooltips to neutral color selector showing color names
- Add tooltips to border radius selector showing rem values
- Position tooltips consistently (right for sidebar, bottom for settings)
- Style tooltips with consistent UI across components
- Hide tooltips when sidebar is expanded