### PR TITLE
feat: add UUID support and improve chat message handling

### DIFF
--- a/components/app/chat/ChatDisplay.vue
+++ b/components/app/chat/ChatDisplay.vue
@@ -1,20 +1,17 @@
 <script setup lang="ts">
-interface Message {
-	role: 'user' | 'assistant';
-	content: string;
-}
+import type { ChatMessage } from '~/stores/chat';
 
 interface Props {
-	messages: Message[];
+	messages: ChatMessage[];
 }
 
 defineProps<Props>();
 
 const { radiusClasses } = useUIUtils();
 
-const getRoleIcon = (role: Message['role']) => (role === 'assistant' ? 'i-heroicons-sparkles' : 'i-heroicons-user');
+const getRoleIcon = (role: ChatMessage['role']) => (role === 'assistant' ? 'i-heroicons-sparkles' : 'i-heroicons-user');
 
-const getMessageClasses = (role: Message['role']) => ({
+const getMessageClasses = (role: ChatMessage['role']) => ({
 	container: ['gap-2', 'items-end', role === 'user' ? 'flex-row-reverse' : 'flex-row'],
 	avatar: [
 		'mb-0.5',
@@ -35,7 +32,7 @@ const getMessageClasses = (role: Message['role']) => ({
 	<div class="flex flex-col gap-2 px-1 py-2">
 		<article
 			v-for="message in messages"
-			:key="message.content"
+			:key="message.id"
 			class="flex"
 			:class="getMessageClasses(message.role).container">
 			<UAvatar

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "dependencies": {
         "@nuxt/ui": "^3.0.0-alpha.10",
         "@pinia/nuxt": "^0.9.0",
+        "@types/uuid": "^10.0.0",
         "@vueuse/nuxt": "^12.3.0",
         "nuxt": "^3.15.0",
         "ollama": "^0.5.11",
         "pinia": "^2.3.0",
+        "uuid": "^11.0.5",
         "vue": "latest",
         "vue-router": "latest"
       },
@@ -4240,6 +4242,12 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
@@ -14023,6 +14031,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "@nuxt/ui": "^3.0.0-alpha.10",
     "@pinia/nuxt": "^0.9.0",
+    "@types/uuid": "^10.0.0",
     "@vueuse/nuxt": "^12.3.0",
     "nuxt": "^3.15.0",
     "ollama": "^0.5.11",
     "pinia": "^2.3.0",
+    "uuid": "^11.0.5",
     "vue": "latest",
     "vue-router": "latest"
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,10 +31,10 @@ const handleSubmit = async (userInput: string) => {
 		currentResponse.value = '';
 
 		// Add user message
-		chatStore.addMessage({ role: 'user', content: userInput });
+		chatStore.addMessage({ role: 'user' as const, content: userInput });
 
 		// Create placeholder for assistant's response
-		chatStore.addMessage({ role: 'assistant', content: '' });
+		chatStore.addMessage({ role: 'assistant' as const, content: '' });
 
 		// Get streaming response
 		const stream = await streamChat({

--- a/stores/chat.ts
+++ b/stores/chat.ts
@@ -1,8 +1,10 @@
 import { useLocalStorage } from '@vueuse/core';
 import { defineStore } from 'pinia';
 import { computed } from 'vue';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface ChatMessage {
+	id: string;
 	role: 'user' | 'assistant';
 	content: string;
 }
@@ -26,8 +28,11 @@ export const useChatStore = defineStore('chat', () => {
 	const isModelSelected = computed(() => Boolean(state.value.selectedModel));
 
 	// Actions
-	function addMessage(message: ChatMessage) {
-		state.value.messages.push(message);
+	function addMessage(message: Omit<ChatMessage, 'id'>) {
+		state.value.messages.push({
+			...message,
+			id: uuidv4(),
+		});
 	}
 
 	function updateLastMessage(content: string) {

--- a/test/stores/chat.test.ts
+++ b/test/stores/chat.test.ts
@@ -32,27 +32,35 @@ describe('useChatStore', () => {
 
 	describe('actions', () => {
 		describe('addMessage', () => {
-			it('should add a user message', () => {
+			it('should add a user message with generated id', () => {
 				const store = useChatStore();
 				const message = { role: 'user' as const, content: 'Hello' };
 
 				store.addMessage(message);
 
-				expect(store.messages).toEqual([message]);
+				expect(store.messages).toHaveLength(1);
+				expect(store.messages[0]).toEqual({
+					...message,
+					id: expect.any(String),
+				});
 				expect(store.hasMessages).toBe(true);
 			});
 
-			it('should add an assistant message', () => {
+			it('should add an assistant message with generated id', () => {
 				const store = useChatStore();
 				const message = { role: 'assistant' as const, content: 'Hi there!' };
 
 				store.addMessage(message);
 
-				expect(store.messages).toEqual([message]);
+				expect(store.messages).toHaveLength(1);
+				expect(store.messages[0]).toEqual({
+					...message,
+					id: expect.any(String),
+				});
 				expect(store.hasMessages).toBe(true);
 			});
 
-			it('should add multiple messages in sequence', () => {
+			it('should add multiple messages with unique ids', () => {
 				const store = useChatStore();
 				const message1 = { role: 'user' as const, content: 'Hello' };
 				const message2 = { role: 'assistant' as const, content: 'Hi!' };
@@ -60,7 +68,12 @@ describe('useChatStore', () => {
 				store.addMessage(message1);
 				store.addMessage(message2);
 
-				expect(store.messages).toEqual([message1, message2]);
+				expect(store.messages).toHaveLength(2);
+				expect(store.messages[0].id).not.toBe(store.messages[1].id);
+				expect(store.messages).toEqual([
+					{ ...message1, id: expect.any(String) },
+					{ ...message2, id: expect.any(String) },
+				]);
 			});
 		});
 
@@ -130,12 +143,17 @@ describe('useChatStore', () => {
 	describe('persistence', () => {
 		it('should persist state to localStorage', () => {
 			const store = useChatStore();
-			store.addMessage({ role: 'user', content: 'Hello' });
+			const message = { role: 'user' as const, content: 'Hello' };
+			store.addMessage(message);
 			store.setSelectedModel('llama2');
 
 			// Create a new store instance to test persistence
 			const newStore = useChatStore();
-			expect(newStore.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+			expect(newStore.messages).toHaveLength(1);
+			expect(newStore.messages[0]).toEqual({
+				...message,
+				id: expect.any(String),
+			});
 			expect(newStore.selectedModel).toBe('llama2');
 		});
 	});


### PR DESCRIPTION
- Introduced UUID generation for chat messages to ensure unique identification.
- Updated ChatMessage interface to include an 'id' field.
- Modified addMessage function to automatically assign a UUID to each message.
- Refactored ChatDisplay component to use the updated ChatMessage type.
- Adjusted tests to verify the addition of unique IDs for messages.

This enhances the chat functionality by ensuring each message can be uniquely identified and managed.